### PR TITLE
feat: add WCAG 2.1 Level A accessibility compliance

### DIFF
--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -4,9 +4,11 @@ interface Props {
   slug: string;
   title: string;
   date: string;
+  rawDate?: string;
   readTime: string;
   tags: string[];
   featureImage?: string;
+  featureImageAlt?: string;
   excerpt?: string;
   index: number;
 }
@@ -15,9 +17,11 @@ export default function BlogCard({
   slug,
   title,
   date,
+  rawDate,
   readTime,
   tags,
   featureImage,
+  featureImageAlt,
   excerpt,
   index,
 }: Props) {
@@ -39,7 +43,7 @@ export default function BlogCard({
           <div className="overflow-hidden rounded-xl border border-white/10">
             <img
               src={featureImage}
-              alt={`${title} feature image`}
+              alt={featureImageAlt || ""}
               loading="lazy"
               className="h-44 w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
             />
@@ -49,22 +53,22 @@ export default function BlogCard({
         {/* Top Section */}
         <div>
           {/* Metadata */}
-          <div className="flex items-center gap-3 text-[13px] font-mono tracking-wide text-text-muted mb-4">
-            <span className="text-accent/80">{date}</span>
-            <span className="w-1 h-1 rounded-full bg-white/20" />
+          <div className="flex items-center gap-3 text-[0.8125rem] font-mono tracking-wide text-text-muted mb-4">
+            <time dateTime={rawDate}>{date}</time>
+            <span className="w-1 h-1 rounded-full bg-white/20" aria-hidden="true" />
             <span>{readTime}</span>
           </div>
 
           {/* Title */}
-          <h3 className="text-xl md:text-2xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300 mb-3">
+          <h2 className="text-xl md:text-2xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300 mb-3">
             <a href={`/blog/${slug}/`} className="after:absolute after:inset-0 after:content-['']">
               {title}
             </a>
-          </h3>
+          </h2>
 
           {/* Excerpt (optional) */}
           {excerpt && (
-            <p className="text-[15px] text-text-secondary leading-relaxed line-clamp-3 font-light opacity-80 group-hover:opacity-100 transition-opacity duration-300">
+            <p className="text-[0.9375rem] text-text-secondary leading-relaxed line-clamp-3 font-light opacity-80 group-hover:opacity-100 transition-opacity duration-300">
               {excerpt}
             </p>
           )}
@@ -77,14 +81,14 @@ export default function BlogCard({
               <a
                 key={tag}
                 href={`/tags/${slugifyTag(tag)}/`}
-                className="relative z-10 px-2.5 py-1 text-[11px] font-mono text-text-secondary bg-white/5 rounded-md border border-white/5 hover:border-accent/30 hover:text-accent-light transition-colors"
+                className="relative z-10 px-2.5 py-1 text-[0.6875rem] font-mono text-text-secondary bg-white/5 rounded-md border border-white/5 hover:border-accent/30 hover:text-accent-light transition-colors"
               >
                 {tag}
               </a>
             ))}
           </div>
           
-          <div className="flex items-center gap-2 text-[13px] font-medium text-accent opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300">
+          <div aria-hidden="true" className="flex items-center gap-2 text-[0.8125rem] font-medium text-accent opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300">
             Read Article
             <svg 
               className="w-4 h-4" 

--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -4,7 +4,7 @@ interface Props {
   slug: string;
   title: string;
   date: string;
-  rawDate?: string;
+  rawDate: string;
   readTime: string;
   tags: string[];
   featureImage?: string;
@@ -43,7 +43,7 @@ export default function BlogCard({
           <div className="overflow-hidden rounded-xl border border-white/10">
             <img
               src={featureImage}
-              alt={featureImageAlt || ""}
+              alt={featureImageAlt || `Feature image for ${title}`}
               loading="lazy"
               className="h-44 w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
             />

--- a/src/components/CertCard.tsx
+++ b/src/components/CertCard.tsx
@@ -66,6 +66,7 @@ export default function CertCard({
                 viewBox="0 0 24 24"
                 className="w-5 h-5"
                 overflow="visible"
+                aria-hidden="true"
                 dangerouslySetInnerHTML={{ __html: customIconMarkup }}
               />
             ) : (
@@ -74,37 +75,38 @@ export default function CertCard({
                 viewBox="0 0 24 24"
                 className="w-5 h-5"
                 fill={issuerColor}
+                aria-hidden="true"
               >
                 <path d={iconPath ?? ""} />
               </svg>
             )}
           </div>
-          <span className="text-[13px] font-mono text-text-muted tracking-wide">
+          <span className="text-[0.8125rem] font-mono text-text-muted tracking-wide">
             {issuer}
           </span>
         </div>
 
         {/* Certification Name */}
-        <h3 className="text-lg md:text-xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300 min-h-[4.5em]">
+        <h2 className="text-lg md:text-xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300 min-h-[4.5em]">
           {name}
-        </h3>
+        </h2>
 
         {/* Divider */}
         <div className="w-full h-px bg-white/5" />
 
         {/* Dates + Status */}
         <div className="flex items-end justify-between gap-4">
-          <div className="flex flex-col gap-1.5 text-[13px] font-mono text-text-muted">
+          <div className="flex flex-col gap-1.5 text-[0.8125rem] font-mono text-text-muted">
             <span>
               <span className="text-accent/80">Achieved</span>{" "}
-              {formatCertDate(achievedDate)}
+              <time dateTime={achievedDate}>{formatCertDate(achievedDate)}</time>
             </span>
             {validUntil ? (
               <span>
                 <span className="text-text-muted">
                   Valid until
                 </span>{" "}
-                {formatCertDate(validUntil)}
+                <time dateTime={validUntil}>{formatCertDate(validUntil)}</time>
               </span>
             ) : (
               <span className="text-emerald-400/80">No Expiration</span>
@@ -113,7 +115,7 @@ export default function CertCard({
 
           {/* Status Badge — only shown when active */}
           {!isExpired && (
-            <span className="px-2.5 py-1 text-[11px] font-mono rounded-md bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+            <span className="px-2.5 py-1 text-[0.6875rem] font-mono rounded-md bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
               Active
             </span>
           )}
@@ -130,6 +132,7 @@ export default function CertCard({
         rel="noopener noreferrer"
         className={cardClassName}
         style={{ animationDelay: delay }}
+        aria-label={`View ${name} credential (opens in new tab)`}
       >
         {content}
       </a>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
             target="_blank"
             rel="noopener noreferrer"
             className="text-text-muted hover:text-white transition-colors duration-200"
-            aria-label="GitHub"
+            aria-label="GitHub (opens in new tab)"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -33,6 +33,7 @@ export default function Footer() {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              aria-hidden="true"
             >
               <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
               <path d="M9 18c-4.51 2-5-2-7-2" />
@@ -43,7 +44,7 @@ export default function Footer() {
             target="_blank"
             rel="noopener noreferrer"
             className="text-text-muted hover:text-[#0077b5] transition-colors duration-200"
-            aria-label="LinkedIn"
+            aria-label="LinkedIn (opens in new tab)"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -55,6 +56,7 @@ export default function Footer() {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              aria-hidden="true"
             >
               <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
               <rect width="4" height="12" x="2" y="9" />
@@ -76,6 +78,7 @@ export default function Footer() {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              aria-hidden="true"
             >
               <rect width="20" height="16" x="2" y="4" rx="2" />
               <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -51,7 +51,11 @@ export default function Hero({ name, bio, roles }: Props) {
               <h1 className="font-display font-bold tracking-tight leading-[1.1] text-[2.5rem] md:text-[clamp(3.5rem,7vw,5.5rem)] pb-2 md:whitespace-nowrap">
                 <span className="text-text">Hey, I'm </span>
                 <span className="text-accent">{name.split(" ")[0]}</span>
-                <span className="inline-block animate-[wave_2.5s_ease-in-out_infinite] origin-[70%_70%] ml-2 md:ml-4 text-white align-baseline">
+                <span
+                  className="inline-block animate-[wave_2.5s_ease-in-out_infinite] origin-[70%_70%] ml-2 md:ml-4 text-white align-baseline"
+                  role="img"
+                  aria-label="waving hand"
+                >
                   👋
                 </span>
               </h1>
@@ -62,7 +66,8 @@ export default function Hero({ name, bio, roles }: Props) {
               className="reveal mt-4 pl-1"
               style={{ animationDelay: "0.35s" }}
             >
-              <div className="text-[clamp(1.2rem,3vw,1.75rem)] font-body font-light text-accent min-h-[1.4em] flex items-center gap-3">
+              <span className="sr-only">{roles.join(", ")}</span>
+              <div aria-hidden="true" className="text-[clamp(1.2rem,3vw,1.75rem)] font-body font-light text-accent min-h-[1.4em] flex items-center gap-3">
                 <TypeIt
                   options={{
                     speed: 50,
@@ -115,7 +120,7 @@ export default function Hero({ name, bio, roles }: Props) {
               className="reveal mt-10 max-w-lg pl-1"
               style={{ animationDelay: "0.55s" }}
             >
-              <p className="text-text-secondary text-[17px] leading-relaxed font-light">
+              <p className="text-text-secondary text-[1.0625rem] leading-relaxed font-light">
                 {bio}
               </p>
             </div>
@@ -128,7 +133,7 @@ export default function Hero({ name, bio, roles }: Props) {
               {/* Primary CTA */}
               <a
                 href="/blog/"
-                className="group relative inline-flex items-center gap-3 px-7 py-3.5 rounded-full bg-accent text-white font-semibold text-[15px] transition-all duration-300 hover:scale-[1.03] overflow-hidden shadow-[0_0_20px_rgba(255,107,0,0.4)] hover:shadow-[0_0_30px_rgba(255,107,0,0.6)]"
+                className="group relative inline-flex items-center gap-3 px-7 py-3.5 rounded-full bg-accent text-white font-semibold text-[0.9375rem] transition-all duration-300 hover:scale-[1.03] overflow-hidden shadow-[0_0_20px_rgba(255,107,0,0.4)] hover:shadow-[0_0_30px_rgba(255,107,0,0.6)]"
               >
                 <span className="relative z-10">Read my blog</span>
                 <svg
@@ -139,6 +144,7 @@ export default function Hero({ name, bio, roles }: Props) {
                   strokeWidth="2.5"
                   strokeLinecap="round"
                   strokeLinejoin="round"
+                  aria-hidden="true"
                 >
                   <path d="M5 12h14" />
                   <path d="m12 5 7 7-7 7" />

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -10,6 +10,7 @@ interface Props {
 
 <nav
   id="navbar"
+  aria-label="Main"
   class="fixed top-0 left-0 right-0 z-50 flex justify-center py-6 pointer-events-none transition-[background-color,border-color,backdrop-filter] duration-500 border-b border-transparent"
 >
   <div
@@ -21,58 +22,72 @@ interface Props {
       id="nav-pills"
       class="flex items-center rounded-full p-1 transition-colors duration-500 bg-black/20 border border-white/5"
     >
-      <a
-        href="/"
-        class:list={[
-          "relative px-3 md:px-5 py-2 rounded-full text-[13px] font-medium transition-all duration-300",
-          active === "home" ? "text-white" : "text-text-muted hover:text-white"
-        ]}
-      >
-        {active === "home" && (
-          <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
-        )}
-        <span class="relative z-10">Home</span>
-      </a>
-      <a
-        href="/blog/"
-        class:list={[
-          "relative px-3 md:px-5 py-2 rounded-full text-[13px] font-medium transition-all duration-300",
-          active === "blog" ? "text-white" : "text-text-muted hover:text-white"
-        ]}
-      >
-        {active === "blog" && (
-          <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
-        )}
-        <span class="relative z-10">Blog</span>
-      </a>
-      <a
-        href="/certifications/"
-        class:list={[
-          "relative px-3 md:px-5 py-2 rounded-full text-[13px] font-medium transition-all duration-300",
-          active === "certifications" ? "text-white" : "text-text-muted hover:text-white"
-        ]}
-      >
-        {active === "certifications" && (
-          <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
-        )}
-        <span class="relative z-10">Certs</span>
-      </a>
-      <a
-        href="/work-history/"
-        class:list={[
-          "relative px-3 md:px-5 py-2 rounded-full text-[13px] font-medium transition-all duration-300",
-          active === "work-history" ? "text-white" : "text-text-muted hover:text-white"
-        ]}
-      >
-        {active === "work-history" && (
-          <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
-        )}
-        <span class="relative z-10">Work</span>
-      </a>
+      <ul role="list" class="flex items-center list-none m-0 p-0">
+        <li>
+          <a
+            href="/"
+            aria-current={active === "home" ? "page" : undefined}
+            class:list={[
+              "relative px-3 md:px-5 py-2 rounded-full text-[0.8125rem] font-medium transition-all duration-300",
+              active === "home" ? "text-white" : "text-text-muted hover:text-white"
+            ]}
+          >
+            {active === "home" && (
+              <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
+            )}
+            <span class="relative z-10">Home</span>
+          </a>
+        </li>
+        <li>
+          <a
+            href="/blog/"
+            aria-current={active === "blog" ? "page" : undefined}
+            class:list={[
+              "relative px-3 md:px-5 py-2 rounded-full text-[0.8125rem] font-medium transition-all duration-300",
+              active === "blog" ? "text-white" : "text-text-muted hover:text-white"
+            ]}
+          >
+            {active === "blog" && (
+              <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
+            )}
+            <span class="relative z-10">Blog</span>
+          </a>
+        </li>
+        <li>
+          <a
+            href="/certifications/"
+            aria-current={active === "certifications" ? "page" : undefined}
+            class:list={[
+              "relative px-3 md:px-5 py-2 rounded-full text-[0.8125rem] font-medium transition-all duration-300",
+              active === "certifications" ? "text-white" : "text-text-muted hover:text-white"
+            ]}
+          >
+            {active === "certifications" && (
+              <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
+            )}
+            <span class="relative z-10">Certs</span>
+          </a>
+        </li>
+        <li>
+          <a
+            href="/work-history/"
+            aria-current={active === "work-history" ? "page" : undefined}
+            class:list={[
+              "relative px-3 md:px-5 py-2 rounded-full text-[0.8125rem] font-medium transition-all duration-300",
+              active === "work-history" ? "text-white" : "text-text-muted hover:text-white"
+            ]}
+          >
+            {active === "work-history" && (
+              <span class="absolute inset-0 bg-white/10 rounded-full border border-white/5 shadow-inner"></span>
+            )}
+            <span class="relative z-10">Work</span>
+          </a>
+        </li>
+      </ul>
     </div>
 
     {/* Separator */}
-    <div id="nav-separator" class="hidden sm:block w-px h-6 mx-2 transition-colors duration-500 bg-border"></div>
+    <div id="nav-separator" class="hidden sm:block w-px h-6 mx-2 transition-colors duration-500 bg-border" aria-hidden="true"></div>
 
     {/* Social Icons */}
     <div class="hidden sm:flex items-center gap-1 pr-2">
@@ -81,7 +96,7 @@ interface Props {
         target="_blank"
         rel="noopener noreferrer"
         class="p-2 text-text-muted hover:text-accent hover:bg-white/5 rounded-full transition-all duration-200"
-        aria-label="GitHub"
+        aria-label="GitHub (opens in new tab)"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -93,6 +108,7 @@ interface Props {
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
           <path d="M9 18c-4.51 2-5-2-7-2" />
@@ -103,7 +119,7 @@ interface Props {
         target="_blank"
         rel="noopener noreferrer"
         class="p-2 text-text-muted hover:text-[#0077b5] hover:bg-white/5 rounded-full transition-all duration-200"
-        aria-label="LinkedIn"
+        aria-label="LinkedIn (opens in new tab)"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -115,6 +131,7 @@ interface Props {
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
           <rect width="4" height="12" x="2" y="9" />
@@ -136,6 +153,7 @@ interface Props {
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <rect width="20" height="16" x="2" y="4" rx="2" />
           <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />

--- a/src/components/WorkTimelineCard.tsx
+++ b/src/components/WorkTimelineCard.tsx
@@ -47,29 +47,30 @@ export default function WorkTimelineCard({
         {/* Company Header */}
         <div className="flex flex-wrap items-start justify-between gap-3 mb-1">
           <div>
-            <h3 className="text-xl md:text-2xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300">
+            <h2 className="text-xl md:text-2xl font-display font-semibold text-text leading-tight group-hover:text-white transition-colors duration-300">
               {companyUrl ? (
                 <a
                   href={companyUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-accent transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+                  aria-label={`${company} (opens in new tab)`}
                 >
                   {company}
                 </a>
               ) : (
                 company
               )}
-            </h3>
-            <p className="text-[13px] font-mono text-text-muted mt-1.5 tracking-wide">
+            </h2>
+            <p className="text-[0.8125rem] font-mono text-text-muted mt-1.5 tracking-wide">
               {location}
             </p>
           </div>
 
           {/* Overall date range pill */}
-          <span className="shrink-0 px-2.5 py-1 text-[11px] font-mono rounded-md bg-accent/10 text-accent border border-accent/20 whitespace-nowrap">
-            {formatWorkDate(earliestStart)} &mdash;{" "}
-            {latestEnd ? formatWorkDate(latestEnd) : "Present"}
+          <span className="shrink-0 px-2.5 py-1 text-[0.6875rem] font-mono rounded-md bg-accent/10 text-accent border border-accent/20 whitespace-nowrap">
+            <time dateTime={earliestStart}>{formatWorkDate(earliestStart)}</time> &mdash;{" "}
+            {latestEnd ? <time dateTime={latestEnd}>{formatWorkDate(latestEnd)}</time> : "Present"}
           </span>
         </div>
 
@@ -86,18 +87,18 @@ export default function WorkTimelineCard({
             >
               {/* Position title + dates */}
               <div className="flex flex-wrap items-baseline justify-between gap-2 mb-2.5">
-                <h4 className="text-[15px] font-display font-medium text-text">
+                <h3 className="text-[0.9375rem] font-display font-medium text-text">
                   {pos.title}
-                </h4>
-                <span className="text-[12px] font-mono text-text-muted whitespace-nowrap">
-                  {formatWorkDate(pos.startDate)} &mdash;{" "}
-                  {pos.endDate ? formatWorkDate(pos.endDate) : "Present"}
+                </h3>
+                <span className="text-[0.75rem] font-mono text-text-muted whitespace-nowrap">
+                  <time dateTime={pos.startDate}>{formatWorkDate(pos.startDate)}</time> &mdash;{" "}
+                  {pos.endDate ? <time dateTime={pos.endDate}>{formatWorkDate(pos.endDate)}</time> : "Present"}
                 </span>
               </div>
 
               {/* Description */}
               {pos.description && (
-                <p className="text-[14px] text-text-secondary font-light leading-relaxed">
+                <p className="text-[0.875rem] text-text-secondary font-light leading-relaxed">
                   {pos.description}
                 </p>
               )}
@@ -108,11 +109,11 @@ export default function WorkTimelineCard({
         {/* Current role indicator */}
         {isCurrent && (
           <div className="mt-6 pt-4 border-t border-white/5 flex items-center gap-2">
-            <span className="relative flex h-2 w-2">
+            <span className="relative flex h-2 w-2" aria-hidden="true">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
             </span>
-            <span className="text-[12px] font-mono text-emerald-400">
+            <span className="text-[0.75rem] font-mono text-emerald-400">
               Current Role
             </span>
           </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,7 @@ const blog = defineCollection({
     tags: z.array(z.string()),
     excerpt: z.string(),
     featureImage: z.string().optional(),
+    featureImageAlt: z.string().optional(),
     draft: z.boolean().optional(),
   }),
 });

--- a/src/content/blog/ephemeral-ado-pipelines-on-k8s.md
+++ b/src/content/blog/ephemeral-ado-pipelines-on-k8s.md
@@ -5,6 +5,7 @@ readTime: "10 min read"
 tags: ["Azure DevOps", "Azure Pipelines", "K8s"]
 excerpt: "At my current job, we use Azure DevOps and Azure Pipelines for code repos and CI/CD. For the vast majority of our pipelines, we use Microsoft's hosted agents. They're easy to us..."
 featureImage: "/img/blog/ephemeral-ado-pipelines-on-k8s/feature.png"
+featureImageAlt: "Azure DevOps pipeline running on an ephemeral Kubernetes agent pod"
 ---
 
 ## Table of Contents
@@ -220,7 +221,7 @@ Next we prepare our Kubernetes environment to run our custom agent container.
 
 1. First we need to generate an Azure DevOps personal access token (PAT) so that our agents can authenticate to ADO. This can be done by clicking the user settings button, and choosing "Personal access tokens":
 
-    <img src="/img/blog/ephemeral-ado-pipelines-on-k8s/pat.png" width="300px" />
+    <img src="/img/blog/ephemeral-ado-pipelines-on-k8s/pat.png" width="300" alt="Azure DevOps user settings menu showing the Personal access tokens option" />
 
     Give the token at minimum the "Read & manage" permission on "Agent Pools".
 
@@ -425,7 +426,7 @@ This `CronJob` does the following:
 Let's test this out!
 
 Here, we see our three agents running in Kubernetes:
-![pods running before](/img/blog/ephemeral-ado-pipelines-on-k8s/pods-before.png)
+![Kubernetes terminal output showing three Azure Pipelines agent pods running before pipeline execution](/img/blog/ephemeral-ado-pipelines-on-k8s/pods-before.png)
 
 We'll create a basic Azure Pipeline and use the pool that we specified in the `AZP_POOL` environment variable to ensure it targets our K8s agents.
 
@@ -442,13 +443,13 @@ steps:
 ```
 
 Based on our job log, we can see agent `azp-agent-75f7f6b597-xfxdr` picked up the job and ran it successfully.
-![job log](/img/blog/ephemeral-ado-pipelines-on-k8s/job.png)
+![Azure DevOps pipeline job log showing successful execution on a Kubernetes-hosted agent](/img/blog/ephemeral-ado-pipelines-on-k8s/job.png)
 
 Now back in K8s, that agent is gone, and a new one has been created to replace it automatically (notice the difference in pod age).
-![pods after running](/img/blog/ephemeral-ado-pipelines-on-k8s/pods-after.png)
+![Kubernetes terminal output showing the original agent pod terminated and a new replacement pod created](/img/blog/ephemeral-ado-pipelines-on-k8s/pods-after.png)
 
 And if we check in Azure DevOps, the agent that ran our job (`azp-agent-75f7f6b597-xfxdr`) has been cleanly removed from the pool, with the new one already registered and ready to accept new jobs.
-![list of agents after](/img/blog/ephemeral-ado-pipelines-on-k8s/agents-after.png)
+![Azure DevOps agent pool showing the old agent removed and a new agent registered and online](/img/blog/ephemeral-ado-pipelines-on-k8s/agents-after.png)
 
 ## Conclusion
 

--- a/src/content/blog/napp-rke2-dns-precheck-failure.md
+++ b/src/content/blog/napp-rke2-dns-precheck-failure.md
@@ -12,7 +12,7 @@ During my quest to roll out the new NSX Application Platform in our production e
 
 During the **Precheck Platform** step of the wizard, the **Kubernetes Cluster DNS Domain Precheck** step reported as failed. When viewing the details, it simply says to contact your administrator, and the [VMware docs](https://docs.vmware.com/en/VMware-NSX/4.0/nsx-application-platform/GUID-BF5917B3-F873-4D8F-BF04-1F7CC5241EE5.html) that have a page for what to do on pre-check failures was conveniently missing a section for this specific check. How helpful... 
 
-![Precheck wizard failure](/img/blog/napp-rke2-dns-precheck-failure/precheck-failure.png)
+![NSX Application Platform installation wizard showing the DNS Domain Precheck step failed](/img/blog/napp-rke2-dns-precheck-failure/precheck-failure.png)
 
 If you just want to skip to the solution [scroll down to the TL;DR](#tldr).
 
@@ -113,7 +113,7 @@ configmap/kubeadm-config created
 ```
 
 If we run the prechecks again, voila, the DNS domain name check is now passing!
-![Precheck wizard success](/img/blog/napp-rke2-dns-precheck-failure/precheck-success.png)
+![NSX Application Platform installation wizard showing the DNS Domain Precheck step now passing](/img/blog/napp-rke2-dns-precheck-failure/precheck-success.png)
 
 ## TL;DR
 Apply the following configmap to your cluster and re-run the wizard:

--- a/src/content/blog/pi-hole-ha-on-k8s.md
+++ b/src/content/blog/pi-hole-ha-on-k8s.md
@@ -5,6 +5,7 @@ readTime: "11 min read"
 tags: ["pihole", "K8s", "RKE2"]
 excerpt: "In my home lab I run a three node Kubernetes cluster using the [RKE2 distribution](https://docs.rke2.io/) from Rancher Labs. I use this for testing/experimentation, running my U..."
 featureImage: "/img/blog/pi-hole-ha-on-k8s/feature.jpg"
+featureImageAlt: "Pi-hole admin dashboard showing DNS query statistics on a Kubernetes cluster"
 ---
 
 ## Introduction
@@ -51,7 +52,7 @@ metadata:
 
 ### Pi-hole Confiration ConfigMap
 
-Next we'll create a ConfigMap that holds any of the (non-secret) Pi-hole configurable options that we'd like to set for each of our instances. The comprehensive list of options can be found [here](https://github.com/pi-hole/docker-pi-hole#environment-variables). These options will later be passed in as environment variables to the Pi-hole pods.
+Next we'll create a ConfigMap that holds any of the (non-secret) Pi-hole configurable options that we'd like to set for each of our instances. The comprehensive list of options can be found in the [Pi-hole Docker environment variables documentation](https://github.com/pi-hole/docker-pi-hole#environment-variables). These options will later be passed in as environment variables to the Pi-hole pods.
 
 ```yaml title="pihole-configmap.yaml" icon="manifest"
 apiVersion: v1
@@ -287,7 +288,7 @@ Take note of the `External-IP` as you will need it later to point your clients t
 
 As a test, try sending a DNS request to the external IP from your local workstation. You should get a response:
 
-![nslookup](/img/blog/pi-hole-ha-on-k8s/nslookup.png)
+![Terminal output of nslookup query showing successful DNS resolution through the Pi-hole service](/img/blog/pi-hole-ha-on-k8s/nslookup.png)
 
 ### Ingress
 
@@ -295,7 +296,7 @@ In order to access the primary Pi-hole's web interface externally, we need to ex
 
 #### TLS Certificate
 
-To secure our web-interface we'll want to first create a TLS certificate using [CertManager](https://cert-manager.io/). You'll need to first create a `ClusterIssuer` for the CA of your choice, I'll be using [Let's Encrypt](https://letsencrypt.org/). The details for how to do this can be found [here](https://cert-manager.io/docs/configuration/acme/).
+To secure our web-interface we'll want to first create a TLS certificate using [CertManager](https://cert-manager.io/). You'll need to first create a `ClusterIssuer` for the CA of your choice, I'll be using [Let's Encrypt](https://letsencrypt.org/). The details for how to do this can be found in the [cert-manager ACME issuer documentation](https://cert-manager.io/docs/configuration/acme/).
 
 Let's create our certificate:
 
@@ -400,10 +401,10 @@ spec:
 #### Create a DNS record
 
 To access the web interface of Pi-hole we need a DNS record point `pihole.home.maxanderson.tech` to the IP address of our ingress controller, but since Pi-hole is going to be our network's DNS service and we can't configure it without the web interface. This creates a chicken and the egg problem. To solve this, create a temporary entry in your hosts file that points `pihole.home.maxanderson.tech` to the external IP address of your ingress controller. In my case this was assigned by MetalLB as `192.168.1.14`.
-![hosts-file](/img/blog/pi-hole-ha-on-k8s/hosts-file.png)
+![Hosts file editor showing a temporary entry mapping pihole.home.maxanderson.tech to the ingress IP address](/img/blog/pi-hole-ha-on-k8s/hosts-file.png)
 
 Access the URL in your browser and you should be able to sign-in with the password specified in the secret object earlier:
-![pihole-dashboard](/img/blog/pi-hole-ha-on-k8s/pihole-dashboard.png)
+![Pi-hole admin dashboard login page showing the web interface is accessible](/img/blog/pi-hole-ha-on-k8s/pihole-dashboard.png)
 
 Once setup is fully complete, you can go back and create a local DNS record within pihole that points to this IP, then remove the hosts file entry.
 
@@ -413,7 +414,7 @@ Now we have three independent instances of Pi-hole, but can only configure the p
 
 #### Orbital-Sync ConfigMap
 
-Orbital-Sync is configured using environment variables. Let's specify our data within a ConfigMap that we later mount as environment variables within the orbital-sync pod. A full list of configuration options can be found [here](https://github.com/mattwebbio/orbital-sync#configuration).
+Orbital-Sync is configured using environment variables. Let's specify our data within a ConfigMap that we later mount as environment variables within the orbital-sync pod. A full list of configuration options can be found in the [Orbital-Sync configuration documentation](https://github.com/mattwebbio/orbital-sync#configuration).
 
 ```yaml title="orbital-sync-configmap.yaml" icon="manifest"
 apiVersion: v1

--- a/src/content/blog/workload-identity-federation-part-1.md
+++ b/src/content/blog/workload-identity-federation-part-1.md
@@ -5,6 +5,7 @@ readTime: "10 min read"
 tags: ["DevOps", "Security", "OIDC", "Workload Identity Federation"]
 excerpt: "As a DevOps Engineer, I’m tasked with ensuring secure and efficient communication between our various cloud and SaaS services. One of the most persistent challenges I encounter..."
 featureImage: "/img/blog/workload-identity-federation-part-1/feature.png"
+featureImageAlt: "Diagram showing workload identity federation flow between cloud providers using OIDC token exchange"
 ---
 
 <p class="post-badge">New article!</p>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,6 +51,7 @@ const imageUrl = image ? new URL(image, siteUrl).toString() : undefined;
     <link href={googleFontUrl} rel="stylesheet" />
   </head>
   <body class="noise-overlay min-h-screen">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="grid-bg" aria-hidden="true"></div>
     {/* Ambient glow - visible on all pages */}
     <div class="hero-glow opacity-60 mix-blend-screen" aria-hidden="true"></div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -26,14 +26,14 @@ const { Content } = await render(post);
 >
   <Navbar active="blog" />
 
-  <main class="relative z-10 max-w-[1100px] w-full mx-auto px-6 md:px-10 pt-28 pb-20 overflow-x-hidden">
+  <main id="main-content" class="relative z-10 max-w-[1100px] w-full mx-auto px-6 md:px-10 pt-28 pb-20 overflow-x-hidden">
     <article>
       {/* Header */}
       <header class="reveal mb-12 max-w-3xl" style="animation-delay: 0.15s;">
         {/* Back link */}
         <a
           href="/blog/"
-          class="group inline-flex items-center gap-2 text-[13px] text-text-muted hover:text-accent transition-colors mb-8"
+          class="group inline-flex items-center gap-2 text-[0.8125rem] text-text-muted hover:text-accent transition-colors mb-8"
         >
           <svg
             class="w-4 h-4 transition-transform duration-200 group-hover:-translate-x-0.5"
@@ -43,6 +43,7 @@ const { Content } = await render(post);
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
+            aria-hidden="true"
           >
             <path d="m15 18-6-6 6-6" />
           </svg>
@@ -55,11 +56,11 @@ const { Content } = await render(post);
         </h1>
 
         {/* Meta */}
-        <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px]">
-          <span class="text-accent font-mono">{formatDate(post.data.date)}</span>
-          <span class="text-border-subtle">|</span>
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-[0.8125rem]">
+          <time datetime={post.data.date.toISOString()} class="text-accent font-mono">{formatDate(post.data.date)}</time>
+          <span class="text-border-subtle" aria-hidden="true">|</span>
           <span class="text-text-muted font-mono">{post.data.readTime}</span>
-          <span class="text-border-subtle">|</span>
+          <span class="text-border-subtle" aria-hidden="true">|</span>
           <div class="flex flex-wrap gap-1.5">
             {post.data.tags.map((tag: string) => (
               <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>{tag}</a>
@@ -73,7 +74,7 @@ const { Content } = await render(post);
         {post.data.featureImage && (
           <img
             src={post.data.featureImage}
-            alt={`${post.data.title} feature image`}
+            alt={post.data.featureImageAlt || ""}
             class="mt-8 w-full rounded-2xl border border-border object-cover shadow-[0_10px_40px_rgba(0,0,0,0.45)]"
             loading="eager"
           />
@@ -89,9 +90,9 @@ const { Content } = await render(post);
       <footer class="reveal mt-16 pt-8 border-t border-border-subtle max-w-3xl" style="animation-delay: 0.4s;">
         <a
           href="/blog/"
-          class="group inline-flex items-center gap-2.5 text-[13px] text-text-secondary hover:text-accent transition-all duration-200"
+          class="group inline-flex items-center gap-2.5 text-[0.8125rem] text-text-secondary hover:text-accent transition-all duration-200"
         >
-          <span class="inline-flex items-center justify-center w-7 h-7 rounded-md border border-border-subtle group-hover:border-accent/30 transition-colors">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-md border border-border-subtle group-hover:border-accent/30 transition-colors" aria-hidden="true">
             <svg
               class="w-3.5 h-3.5"
               viewBox="0 0 24 24"

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -26,7 +26,7 @@ const { Content } = await render(post);
 >
   <Navbar active="blog" />
 
-  <main id="main-content" class="relative z-10 max-w-[1100px] w-full mx-auto px-6 md:px-10 pt-28 pb-20 overflow-x-hidden">
+  <main id="main-content" tabindex="-1" class="relative z-10 max-w-[1100px] w-full mx-auto px-6 md:px-10 pt-28 pb-20 overflow-x-hidden">
     <article>
       {/* Header */}
       <header class="reveal mb-12 max-w-3xl" style="animation-delay: 0.15s;">
@@ -74,7 +74,7 @@ const { Content } = await render(post);
         {post.data.featureImage && (
           <img
             src={post.data.featureImage}
-            alt={post.data.featureImageAlt || ""}
+            alt={post.data.featureImageAlt || `Feature image for ${post.data.title}`}
             class="mt-8 w-full rounded-2xl border border-border object-cover shadow-[0_10px_40px_rgba(0,0,0,0.45)]"
             loading="eager"
           />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -17,13 +17,13 @@ const posts = sortPostsByDate(getVisiblePosts(allPosts));
 <BaseLayout title="Blog — Max Anderson">
   <Navbar active="blog" />
 
-  <main class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     {/* Header */}
     <div class="reveal mb-12" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">
         Blog
       </h1>
-      <p class="text-text-secondary text-[17px] mt-3 max-w-xl">
+      <p class="text-text-secondary text-[1.0625rem] mt-3 max-w-xl">
         Thoughts on DevOps, cloud infrastructure, automation, and the tools that make it all work.
       </p>
     </div>
@@ -35,9 +35,11 @@ const posts = sortPostsByDate(getVisiblePosts(allPosts));
           slug={post.id}
           title={post.data.title}
           date={formatDateShort(post.data.date)}
+          rawDate={post.data.date.toISOString()}
           readTime={post.data.readTime}
           tags={post.data.tags}
           featureImage={post.data.featureImage}
+          featureImageAlt={post.data.featureImageAlt}
           excerpt={post.data.excerpt}
           index={i}
         />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -17,7 +17,7 @@ const posts = sortPostsByDate(getVisiblePosts(allPosts));
 <BaseLayout title="Blog — Max Anderson">
   <Navbar active="blog" />
 
-  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" tabindex="-1" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     {/* Header */}
     <div class="reveal mb-12" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">

--- a/src/pages/certifications/index.astro
+++ b/src/pages/certifications/index.astro
@@ -49,7 +49,7 @@ const resolvedCerts: ResolvedCert[] = certifications.map((cert: Certification) =
 <BaseLayout title="Certifications — Max Anderson">
   <Navbar active="certifications" />
 
-  <main class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     {/* Header */}
     <div class="reveal mb-12" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">

--- a/src/pages/certifications/index.astro
+++ b/src/pages/certifications/index.astro
@@ -49,7 +49,7 @@ const resolvedCerts: ResolvedCert[] = certifications.map((cert: Certification) =
 <BaseLayout title="Certifications — Max Anderson">
   <Navbar active="certifications" />
 
-  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" tabindex="-1" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     {/* Header */}
     <div class="reveal mb-12" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import { siteData } from "../data/site";
 <BaseLayout showRunners>
   <Navbar active="home" />
 
-  <main id="main-content">
+  <main id="main-content" tabindex="-1">
     <Hero
       client:idle
       name={siteData.name}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,16 +9,18 @@ import { siteData } from "../data/site";
 <BaseLayout showRunners>
   <Navbar active="home" />
 
-  <Hero
-    client:idle
-    name={siteData.name}
-    bio={siteData.bio}
-    roles={[
-      "DevOps Engineer",
-      "Cloud Engineer",
-      "Systems & Network Engineer",
-    ]}
-  />
+  <main id="main-content">
+    <Hero
+      client:idle
+      name={siteData.name}
+      bio={siteData.bio}
+      roles={[
+        "DevOps Engineer",
+        "Cloud Engineer",
+        "Systems & Network Engineer",
+      ]}
+    />
+  </main>
 
   <Footer />
 </BaseLayout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -41,7 +41,7 @@ const posts = sortPostsByDate(
 <BaseLayout title={`${tag} — Tags — Max Anderson`}>
   <Navbar active="blog" />
 
-  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" tabindex="-1" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     <div class="reveal mb-10" style="animation-delay: 0.15s;">
       <a
         href="/tags/"

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -41,11 +41,11 @@ const posts = sortPostsByDate(
 <BaseLayout title={`${tag} — Tags — Max Anderson`}>
   <Navbar active="blog" />
 
-  <main class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     <div class="reveal mb-10" style="animation-delay: 0.15s;">
       <a
         href="/tags/"
-        class="group inline-flex items-center gap-2 text-[13px] text-text-muted hover:text-accent transition-colors mb-7"
+        class="group inline-flex items-center gap-2 text-[0.8125rem] text-text-muted hover:text-accent transition-colors mb-7"
       >
         <svg
           class="w-4 h-4 transition-transform duration-200 group-hover:-translate-x-0.5"
@@ -55,6 +55,7 @@ const posts = sortPostsByDate(
           stroke-width="2"
           stroke-linecap="round"
           stroke-linejoin="round"
+          aria-hidden="true"
         >
           <path d="m15 18-6-6 6-6" />
         </svg>
@@ -64,7 +65,7 @@ const posts = sortPostsByDate(
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">
         {tag}
       </h1>
-      <p class="text-text-secondary text-[17px] mt-3 max-w-xl">
+      <p class="text-text-secondary text-[1.0625rem] mt-3 max-w-xl">
         {posts.length} {posts.length === 1 ? "post" : "posts"} tagged with {tag}.
       </p>
     </div>
@@ -75,9 +76,11 @@ const posts = sortPostsByDate(
           slug={post.id}
           title={post.data.title}
           date={formatDateShort(post.data.date)}
+          rawDate={post.data.date.toISOString()}
           readTime={post.data.readTime}
           tags={post.data.tags}
           featureImage={post.data.featureImage}
+          featureImageAlt={post.data.featureImageAlt}
           excerpt={post.data.excerpt}
           index={i}
         />

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -21,23 +21,25 @@ const tags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 <BaseLayout title="Tags — Max Anderson">
   <Navbar active="blog" />
 
-  <main class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     <div class="reveal mb-10" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">
         Tags
       </h1>
-      <p class="text-text-secondary text-[17px] mt-3 max-w-xl">
+      <p class="text-text-secondary text-[1.0625rem] mt-3 max-w-xl">
         Browse posts by topic.
       </p>
     </div>
 
-    <div class="reveal flex flex-wrap gap-3" style="animation-delay: 0.25s;">
+    <ul role="list" class="reveal flex flex-wrap gap-3 list-none m-0 p-0" style="animation-delay: 0.25s;">
       {tags.map(([tag, count]) => (
-        <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>
-          {tag} ({count})
-        </a>
+        <li>
+          <a class="tag" href={`/tags/${slugifyTag(tag)}/`}>
+            {tag} ({count})
+          </a>
+        </li>
       ))}
-    </div>
+    </ul>
   </main>
 
   <Footer />

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -21,7 +21,7 @@ const tags = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 <BaseLayout title="Tags — Max Anderson">
   <Navbar active="blog" />
 
-  <main id="main-content" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" tabindex="-1" class="relative z-10 max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     <div class="reveal mb-10" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">
         Tags

--- a/src/pages/work-history/index.astro
+++ b/src/pages/work-history/index.astro
@@ -9,7 +9,7 @@ import { workHistory } from "../../data/work-history";
 <BaseLayout title="Work History — Max Anderson" description="Professional work history and career timeline for Max Anderson.">
   <Navbar active="work-history" />
 
-  <main class="relative z-10 w-full max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
+  <main id="main-content" tabindex="-1" class="relative z-10 w-full max-w-[1100px] mx-auto px-6 md:px-10 pt-28 pb-20">
     {/* Header */}
     <div class="reveal mb-16" style="animation-delay: 0.15s;">
       <h1 class="font-display font-extrabold text-[clamp(2rem,5vw,3rem)] tracking-tight leading-tight text-text">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -78,6 +78,33 @@
     background: rgba(255, 107, 0, 0.2);
     color: #fff;
   }
+
+  /* ===== Focus styles ===== */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+}
+
+/* ===== Skip navigation ===== */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-accent);
+  color: #fff;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 0.875rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 0;
 }
 
 /* ===== Utility Classes ===== */
@@ -222,7 +249,7 @@
 .tag {
   display: inline-block;
   padding: 3px 10px;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
   color: var(--color-text-secondary);
@@ -693,8 +720,21 @@
   }
 }
 
-/* === Reduced motion === */
+/* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .reveal {
+    animation: none;
+    opacity: 1;
+  }
+
+  .hero-glow {
+    animation: none;
+  }
+
   .timeline-entry {
     opacity: 1;
     transform: none;
@@ -709,5 +749,13 @@
 
   .timeline-entry .animate-ping {
     animation: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary

Adds WCAG 2.1 Level A accessibility compliance across the entire site, plus additional improvements for reduced-motion support, scalable font sizing, and descriptive blog content alt text.

### Changes by category

**Skip Navigation & Landmarks**
- Added a visually-hidden "Skip to main content" link in `BaseLayout.astro` (only visible on keyboard Tab)
- Added `<main id="main-content" tabindex="-1">` to the homepage; added `id="main-content" tabindex="-1"` to all other pages for proper skip-link focus management
- Added `aria-label="Main"` to the `<nav>` element

**Focus Styles**
- Added global `:focus-visible` outline rule — only appears during keyboard navigation, never on mouse click

**ARIA Attributes**
- `aria-current="page"` on the active navbar link
- `aria-hidden="true"` on ~15 decorative SVG icons across Navbar, Footer, Hero, BlogCard, CertCard, and page templates
- `aria-hidden="true"` on decorative separators (dot, pipe characters, navbar divider)
- `aria-hidden="true"` on the BlogCard "Read Article" hover-only text
- `aria-hidden="true"` on the WorkTimelineCard decorative ping animation
- `aria-label` on CertCard external links with concise accessible names
- `aria-label` with "(opens in new tab)" on WorkTimelineCard company links
- `role="img"` and `aria-label` on the waving hand emoji
- Screen-reader-only fallback text for the TypeIt animation, with `aria-hidden` on the animated container
- "(opens in new tab)" appended to all external link `aria-label` values

**Semantic HTML**
- Navbar links wrapped in `<ul>/<li>` list structure
- Tags index page links wrapped in `<ul>/<li>` list
- Blog card heading changed from `<h3>` to `<h2>` (fixes heading level skip)
- CertCard heading changed from `<h3>` to `<h2>` (fixes heading level skip)
- WorkTimelineCard heading levels fixed (`<h3>` → `<h2>`, `<h4>` → `<h3>`)
- Dates wrapped in `<time>` elements with machine-readable `datetime` attributes (blog, certs, and work history)

**Reduced Motion**
- Added `@media (prefers-reduced-motion: reduce)` block disabling all CSS animations and smooth scrolling

**Font Sizing**
- Converted all instances of `text-[Npx]` Tailwind classes to `rem` equivalents across all components
- Converted `.tag` CSS `font-size: 12px` to `0.75rem`

**Content & Alt Text**
- Added `featureImageAlt` optional field to the blog content schema
- Added descriptive `featureImageAlt` values to all 3 posts with feature images
- Feature image `alt` falls back to title-based text instead of empty string when `featureImageAlt` is not provided
- Fixed 1 `<img>` tag missing an `alt` attribute entirely
- Improved vague/terse alt text on 9 blog post images
- Replaced 3 instances of "here" link text with descriptive link text

**Code Quality**
- Made `rawDate` prop required in `BlogCard` (was optional but always passed)

### Files changed
- `src/styles/global.css` — focus styles, skip-link styles, reduced-motion, tag px→rem
- `src/layouts/BaseLayout.astro` — skip navigation link
- `src/pages/index.astro` — `<main>` landmark wrapper with `tabindex="-1"`
- `src/pages/blog/index.astro`, `src/pages/blog/[...slug].astro`, `src/pages/tags/index.astro`, `src/pages/tags/[tag].astro`, `src/pages/certifications/index.astro`, `src/pages/work-history/index.astro` — `id="main-content" tabindex="-1"`, ARIA fixes, semantic improvements
- `src/components/Navbar.astro` — aria-label, aria-current, ul/li, aria-hidden, external link labels
- `src/components/Hero.tsx` — emoji a11y, TypeIt sr-only fallback, SVG aria-hidden
- `src/components/BlogCard.tsx` — featureImageAlt prop with title fallback, rawDate required, h3→h2, aria-hidden, `<time>`
- `src/components/CertCard.tsx` — aria-hidden on SVGs, aria-label on link, h3→h2, `<time>`
- `src/components/WorkTimelineCard.tsx` — heading levels, `<time>` elements, px→rem, aria-label on company link, aria-hidden on ping dot
- `src/components/Footer.tsx` — aria-hidden on SVGs, external link labels
- `src/content.config.ts` — featureImageAlt schema field
- `src/content/blog/*.md` (4 files) — alt text fixes, descriptive link text